### PR TITLE
Add support for HS105 protocol

### DIFF
--- a/tplink-smartplug.py
+++ b/tplink-smartplug.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
-# 
+#
 # TP-Link Wi-Fi Smart Plug Protocol Client
 # For use with TP-Link HS-100 or HS-110
-#  
+#
 # by Lubomir Stroetmann
-# Copyright 2016 softScheck GmbH 
-# 
+# Copyright 2016 softScheck GmbH
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 #
 import socket
 import argparse
@@ -30,7 +30,7 @@ def validIP(ip):
 		socket.inet_pton(socket.AF_INET, ip)
 	except socket.error:
 		parser.error("Invalid IP Address.")
-	return ip 
+	return ip
 
 # Predefined Smart Plug Commands
 # For a full list of commands, consult tplink_commands.txt
@@ -52,18 +52,18 @@ commands = {'info'     : '{"system":{"get_sysinfo":{}}}',
 def encrypt(string):
 	key = 171
 	result = "\0\0\0\0"
-	for i in string: 
+	for i in string:
 		a = key ^ ord(i)
 		key = a
 		result += chr(a)
 	return result
 
 def decrypt(string):
-	key = 171 
+	key = 171
 	result = ""
-	for i in string: 
+	for i in string:
 		a = key ^ ord(i)
-		key = ord(i) 
+		key = ord(i)
 		result += chr(a)
 	return result
 
@@ -71,7 +71,7 @@ def decrypt(string):
 parser = argparse.ArgumentParser(description="TP-Link Wi-Fi Smart Plug Client v" + str(version))
 parser.add_argument("-t", "--target", metavar="<ip>", required=True, help="Target IP Address", type=validIP)
 group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument("-c", "--command", metavar="<command>", help="Preset command to send. Choices are: "+", ".join(commands), choices=commands) 
+group.add_argument("-c", "--command", metavar="<command>", help="Preset command to send. Choices are: "+", ".join(commands), choices=commands)
 group.add_argument("-j", "--json", metavar="<JSON string>", help="Full JSON string of command to send")
 args = parser.parse_args()
 
@@ -85,14 +85,14 @@ else:
 
 
 
-# Send command and receive reply 
+# Send command and receive reply
 try:
 	sock_tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	sock_tcp.connect((ip, port))
 	sock_tcp.send(encrypt(cmd))
 	data = sock_tcp.recv(2048)
 	sock_tcp.close()
-	
+
 	print "Sent:     ", cmd
 	print "Received: ", decrypt(data[4:])
 except socket.error:

--- a/tplink-smartplug.py
+++ b/tplink-smartplug.py
@@ -21,6 +21,7 @@
 #
 import socket
 import argparse
+import struct
 
 version = 0.1
 
@@ -51,7 +52,7 @@ commands = {'info'     : '{"system":{"get_sysinfo":{}}}',
 # XOR Autokey Cipher with starting key = 171
 def encrypt(string):
 	key = 171
-	result = "\0\0\0\0"
+	result = struct.pack(">I", len(string))
 	for i in string:
 		a = key ^ ord(i)
 		key = a


### PR DESCRIPTION
Compared to the HS100 and HS110, where messages sent and received begin with a four-byte  header that can be safely ignored (and set to
zero in the existing code), the HS105 mini-plug requires queries to have a correct length header matching the message length.

This changeset provides such a header when sending queries. We still ignore the header when receiving responses from the smart plug.
