### PR TITLE
Refactored for native python3 support (maintain python2 support with version detection)

### DIFF
--- a/tplink_smartplug.py
+++ b/tplink_smartplug.py
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+import sys
 import socket
 import argparse
 from struct import pack
@@ -51,23 +52,43 @@ commands = {'info'     : '{"system":{"get_sysinfo":{}}}',
 
 # Encryption and Decryption of TP-Link Smart Home Protocol
 # XOR Autokey Cipher with starting key = 171
-def encrypt(string):
-	key = 171
-	result = pack('>I', len(string))
-	for i in string:
-		a = key ^ ord(i)
-		key = a
-		result += chr(a)
-	return result
+if sys.version_info[0] > 2:
+	def encrypt(string):
+		key = 171
+		result = pack('>I', len(string))
+		for i in string:
+			a = key ^ ord(i)
+			key = a
+			result += bytes([a])
+		return result
 
-def decrypt(string):
-	key = 171
-	result = ""
-	for i in string:
-		a = key ^ ord(i)
-		key = ord(i)
-		result += chr(a)
-	return result
+	def decrypt(string):
+		key = 171
+		result = ""
+		for i in string:
+			a = key ^ i
+			key = i
+			result += chr(a)
+		return result
+
+else:
+	def encrypt(string):
+		key = 171
+		result = pack('>I', len(string))
+		for i in string:
+			a = key ^ ord(i)
+			key = a
+			result += chr(a)
+		return result
+
+	def decrypt(string):
+		key = 171
+		result = ""
+		for i in string:
+			a = key ^ ord(i)
+			key = ord(i)
+			result += chr(a)
+		return result
 
 # Parse commandline arguments
 parser = argparse.ArgumentParser(description="TP-Link Wi-Fi Smart Plug Client v" + str(version))
@@ -96,8 +117,7 @@ try:
 	data = sock_tcp.recv(2048)
 	sock_tcp.close()
 
-	print "Sent:     ", cmd
-	print "Received: ", decrypt(data[4:])
+	print("Sent:     ", cmd)
+	print("Received: ", decrypt(data[4:]))
 except socket.error:
 	quit("Cound not connect to host " + ip + ":" + str(port))
-

--- a/tplink_smartplug.py
+++ b/tplink_smartplug.py
@@ -52,6 +52,7 @@ commands = {'info'     : '{"system":{"get_sysinfo":{}}}',
 
 # Encryption and Decryption of TP-Link Smart Home Protocol
 # XOR Autokey Cipher with starting key = 171
+# Python 3.x Version
 if sys.version_info[0] > 2:
 	def encrypt(string):
 		key = 171
@@ -71,6 +72,7 @@ if sys.version_info[0] > 2:
 			result += chr(a)
 		return result
 
+# Python 2.x Version
 else:
 	def encrypt(string):
 		key = 171


### PR DESCRIPTION
The same script can now be run on Python 2 and Python 3

Main issues between Python 2.x and Python 3.x on this script are the handling of bytes/strings and the print statements.

Changes made:
- Changed print statements to use the print() function that both versions support
- Added another set of encrypt/decrypt functions that are chosen using version detection. 

There are no changes to the functionality of the script. You can run it with exactly the same arguments as you could before. Should be more or less a drop in replacement for everyone as long as the print statement formatting doesn't screw things up for you. It also allows for people to use this script with Python 3 in the future. 

If you don't like the giant if statement you can choose which functions you want depending on the version you are using and delete the other one in your own projects. First set of encode/decode is for python3 the second set is for python 2