### PR TITLE
Add option for individual outlet control on HS300 and HS303 power strips

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The same commands can be modified to control a single outlet by inserting `"cont
 For instance:
 `{"system":{"set_led_off":{"off":0}}}` Will turn all outlets off
 
-'{"context":{"child_ids":["8006...E101"]}, "system":{"set_led_off":{"off":0}}}' Will turn just that one outlet on
+`'{"context":{"child_ids":["8006...E101"]}, "system":{"set_led_off":{"off":0}}}'` Will turn just that one outlet on
 
 You can specify multiple child outlet IDs by adding them to the `child_ids` array in your command.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,24 @@ Provide the target IP using `-t` and a command to send using either `-c` or `-j`
 | reset     | Reset the device to factory settings |
 | energy    | Return realtime voltage/current/power|
 
+When using commands from the `-c` list on power strips HS300 and HS303, you can use the `-o` flag to specify a specific outlet on the power strip using the child ID.
+The child ID can be obtained by running the info command on the power strip at looking in the `"system"` > `"get_sysinfo"` > `"children"` sections.
+
 More advanced commands such as creating or editing rules can be issued using the `-j` flag by providing the full JSON string for the command. Please consult [tplink-smarthome-commands.txt](tplink-smarthome-commands.txt) for a comprehensive list of commands.
+
+#### Modifying Commands for HS300 and HS303 for the `-j` flag ####
+
+The same commands can be modified to control a single outlet by inserting `"context":{"child_ids":["CHILD_ID"]}, ` in front of `"system":`. If you dont specify a child outlet, the command will affect the entire power strip.
+
+For instance:
+`{"system":{"set_led_off":{"off":0}}}` Will turn all outlets off
+
+'{"context":{"child_ids":["8006...E101"]}, "system":{"set_led_off":{"off":0}}}' Will turn just that one outlet on
+
+You can specify multiple child outlet IDs by adding them to the `child_ids` array in your command.
+
+Some commands are not outlet specific (ex. `info`) so the child ID(s) will be ignored by your power strip.
+
 
 ## Wireshark Dissector ##
 

--- a/tplink_smartplug.py
+++ b/tplink_smartplug.py
@@ -49,10 +49,10 @@ def validPort(port):
 
 # Predefined Smart Plug Commands
 # For a full list of commands, consult tplink_commands.txt
-commands = {		'info'     : '{"system":{"get_sysinfo":{}}}',
+commands = {'info'     : '{"system":{"get_sysinfo":{}}}',
 			'on'       : '{"system":{"set_relay_state":{"state":1}}}',
 			'off'      : '{"system":{"set_relay_state":{"state":0}}}',
-	    		'ledoff'   : '{"system":{"set_led_off":{"off":1}}}',
+	    	'ledoff'   : '{"system":{"set_led_off":{"off":1}}}',
 			'ledon'    : '{"system":{"set_led_off":{"off":0}}}',
 			'cloudinfo': '{"cnCloud":{"get_info":{}}}',
 			'wlanscan' : '{"netif":{"get_scaninfo":{"refresh":0}}}',
@@ -113,6 +113,8 @@ parser.add_argument("-t", "--target", metavar="<hostname>", required=True, help=
 parser.add_argument("-p", "--port", metavar="<port>", default=9999, required=False, help="Target port", type=validPort)
 parser.add_argument("-q", "--quiet", dest='quiet', action='store_true', help="Only show result")
 parser.add_argument("--timeout", default=10, required=False, help="Timeout to establish connection")
+parser.add_argument("-o", "--outlet", metavar="<outletID>", help="Child outlet ID. Typically around 42 characters. "
+																  "Will be ignored if manually specifying JSON. Use info command to get child IDs")
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument("-c", "--command", metavar="<command>", help="Preset command to send. Choices are: "+", ".join(commands), choices=commands)
 group.add_argument("-j", "--json", metavar="<JSON string>", help="Full JSON string of command to send")
@@ -126,7 +128,8 @@ if args.command is None:
 	cmd = args.json
 else:
 	cmd = commands[args.command]
-
+	if args.outlet is not None:
+		cmd = '{"context":{"child_ids":["' + args.outlet + '"]}, ' + cmd[1:]
 
 
 # Send command and receive reply


### PR DESCRIPTION
This pull requests adds some documentation and basic code to modify the commands and show how to control individual outlets on a TP-Link Kasa power strip. 

## Overview
As it is, this script can control power strips as a single entity. All switches on/off, timer/schedule set for all outlets, etc.
By adding a specially formatted piece of data you can control outlets individually.

Existing commands:
1. `{"system":{"set_relay_state":{"state":1}}}`
2. `{"system":{"set_relay_state":{"state":0}}}`

New commands for HS300/303
1. `{"context":{"child_ids":["8006...E101"]}, "system":{"set_relay_state":{"state":1}}}`
2. `{"context":{"child_ids":["8006...E101"]}, "system":{"set_relay_state":{"state":0}}}`



## `child_ids`
Child IDs are 42 character long Hexadecemal strings. You can get these values by running the info command on the power strip.

For instance, I have the HS303 power strip and when I run `{"system":{"get_sysinfo":{}}}` it will return the following JSON:
``` json
{
  "system": {
    "get_sysinfo": {
      "sw_ver": "1.0.9 Build 191031 Rel.095941",
      "hw_ver": "1.0",
      "model": "KP303(US)",
      "deviceId": "8006243B...AAE1",
      .
      .
      .
      "led_off": 0,
      "children": [
        {
          "id": "8006243B...AAE100",
          "state": 1,
          "alias": "Do not turn off!!!",
          "on_time": -3372260,
          "next_action": {
            "type": -1
          }
        },
        {
          "id": "8006243B...AAE101",
          "state": 0,
          "alias": "Plug 2",
          "on_time": 545,
          "next_action": {
            "type": -1
          }
        },
        {
          "id": "8006243B...AAE102",
          "state": 1,
          "alias": "Heat Pad",
          "on_time": 36062,
          "next_action": {
            "type": -1
          }
        }
      ],
      "child_num": 3,
      "ntc_state": 0,
      "err_code": 0
    }
  }
}
```
Some lines have been omitted to shorten the length

If you look under `"system"` > `"get_sysinfo"` > `"children"` you can see the ID and alias for each of the outlets on your power strip.

These child IDs should be just the `deviceId` + a 2 digit number representing the position of the outlet on your device (00 - 06 or 00 - 02 depending on which one you have)

### Multiple Control

You can actually control multiple outlets at once by specifying multiple IDs in the command JSON array. 
Only outlet 1:  `{"context":{"child_ids":["8006...E101"]}, "system":{"set_relay_state":{"state":0}}}`
Only outlet 1 and 2: `{"context":{"child_ids":["8006...E101","8006...E102"]}, "system":{"set_relay_state":{"state":0}}}`