### PR TITLE
Fix character encoding of response

### DIFF
--- a/tplink_smartplug.py
+++ b/tplink_smartplug.py
@@ -78,12 +78,12 @@ def encrypt(string):
 
 def decrypt(string):
     key = 171
-    result = ""
+    result = []
     for i in string:
         a = key ^ i
         key = i
-        result += chr(a)
-    return result
+        result.append(a)
+    return bytearray(result).decode('utf-8')
 
 
 # Parse commandline arguments


### PR DESCRIPTION
Apparently, the response JSON is UTF-8 encoded and may contain multi-byte characters, e.g., for the device name (system / get_sysinfo / alias).

This patch fixes the response for a HS110 with Firmware 1.0.5.